### PR TITLE
As postData is set to an empty string, isset() always returns true…

### DIFF
--- a/Source/Kite/OhMyEmma/Request.php
+++ b/Source/Kite/OhMyEmma/Request.php
@@ -111,7 +111,7 @@ class Request
         curl_setopt($ch, CURLOPT_USERPWD, $this->_public . ":" . $this->_private);
         curl_setopt($ch, CURLOPT_URL, $url);
 
-        if (isset($this->postData)) {
+        if (!empty($this->postData)) {
             curl_setopt($ch, CURLOPT_POST, count($this->postData));
             curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($this->postData));
         }


### PR DESCRIPTION
…and the curl_setopt calls affect GET requests for newer versions of curl. Switching to !empty().