### PR TITLE
Add Support for Events API

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Create a new instance by providing account credentials.
 </pre>
 
 Available interfaces are: (case sensitive)
+* Events
 * Fields
 * Groups
 * Mailings

--- a/Source/Kite/OhMyEmma/Emma.php
+++ b/Source/Kite/OhMyEmma/Emma.php
@@ -15,6 +15,7 @@
 
 namespace Kite\OhMyEmma;
 
+use Kite\OhMyEmma\Interfaces\Events;
 use Kite\OhMyEmma\Interfaces\Fields;
 use Kite\OhMyEmma\Interfaces\Groups;
 use Kite\OhMyEmma\Interfaces\Mailings;
@@ -75,6 +76,7 @@ class Emma
 
         //check if the passed property matches our interfaces
         if(in_array($interface, array(
+            'Events',
             'Fields',
             'Groups',
             'Mailings',

--- a/Source/Kite/OhMyEmma/Interfaces/Events.php
+++ b/Source/Kite/OhMyEmma/Interfaces/Events.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * This file is part of the Kite\OhMyEmma Library
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Author Neal Lambert
+ * @crankeye on GitHub
+ * https://github.com/jwoodcock/CurlBack
+ *
+ * @license http://opensource.org/licenses/BSD-3-Clause BSD 3-Clause
+ */
+
+namespace Kite\OhMyEmma\Interfaces;
+
+/**
+ * Class for creating events using the /events endpoint.
+ * For full details of data formats and individual endpoints
+ * refer to MyEmma.com's documentation. Last found here:
+ * http://api.myemma.com/api/external/event_api.html
+ */
+class Events
+{
+
+    /**
+     * Request Object passed in via the 
+     * factory controller. 
+     *
+     * @var object 
+     */
+    private $_request = '';
+
+    /**
+     * Emma url for events api.
+     *
+     * @var string
+     */
+    private $_baseURL = 'https://events.e2ma.net/v1/';
+
+    /**
+     * Construct the member object which 
+     * requires the request object from 
+     * the factory
+     *
+     * @param object $request
+     */
+    public function __construct($request)
+    {
+        if (is_object($request)) {
+            $this->_request = clone $request;
+            $this->_request->_baseURL = $this->_baseURL;
+        } else {
+            return 'You can not use this class without a valid request object';
+        }
+    }
+
+    /**
+     * Method for creating a new event
+     * Must include a valid email address and the
+     * member must currently have and "Active" status.
+     *
+     * @param string $email
+     * @param array $fields
+     */
+    public function createEvent($email, $fields = [])
+    {
+        $this->_request->method = 'POST';
+        $url = "events";
+
+        $fields['email'] = $email;
+        $this->_request->postData = $fields;
+
+        return $this->_request->processRequest($url);
+    }
+
+}

--- a/Source/Kite/OhMyEmma/Interfaces/Groups.php
+++ b/Source/Kite/OhMyEmma/Interfaces/Groups.php
@@ -17,7 +17,7 @@ namespace Kite\OhMyEmma\Interfaces;
 
 /**
  * Class for manipulating creation, updated and deleting 
- * groups using the /groups enpoint. For full details
+ * groups using the /groups endpoint. For full details
  * of data formats and individual endpoints refer
  * to MyEmma.com's documentation. Last found here:
  * http://api.myemma.com/api/external/groups.html

--- a/Source/Kite/OhMyEmma/Request.php
+++ b/Source/Kite/OhMyEmma/Request.php
@@ -71,7 +71,7 @@ class Request
      *
      * @var string
      */
-    private $_baseURL = 'https://api.e2ma.net/';
+    public $_baseURL = 'https://api.e2ma.net/';
 
     /**
      *

--- a/Tests/Kite/OhMyEmma/Interfaces/EventsTest.php
+++ b/Tests/Kite/OhMyEmma/Interfaces/EventsTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Kite\OhMyEmma\Interfaces;
+
+use mocks\RequestMock as RequestMock;
+
+class EventsTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Members
+     */
+    protected $members;
+    protected $request;
+
+    /**
+     * Sets up the fixture, for example, opens a network connection.
+     * This method is called before a test is executed.
+     */
+    protected function setUp()
+    {
+        $this->request = new RequestMock();
+        $this->assertEquals('', $this->request->baseURL);
+ 
+        $this->members = new Members($this->request);
+        $this->assertObjectHasAttribute('_request', $this->members);
+    }
+
+    /**
+     * Tears down the fixture, for example, closes a network connection.
+     * This method is called after a test is executed.
+     */
+    protected function tearDown()
+    {
+    }
+
+    /**
+     * @covers Kite\OhMyEmma\Interfaces\Events::createEvent
+     */
+    public function testCreateEvent()
+    {
+        $this->request = new RequestMock();
+        $this->events = new Events($this->request);
+
+        // Test creating a new event
+        $this->assertEquals('events?email=foo%40baz.com', $this->events->createEvent('foo@baz.com'), ['event_name' => 'foo_event']);
+    }
+}


### PR DESCRIPTION
## Changes
- Adds a new Interface for the events API
- Changes $_baseURL to be public so it can be changed for the events API
- Fixes a typo in the comment

## Example
```
$email = 'foo@baz.com';
$fields = ['event_name' => 'example event name'];
$emma->Events->createEvent($email, $fields);
```